### PR TITLE
fix for exception in saving Cancelled projects

### DIFF
--- a/project_budget/models/projects.py
+++ b/project_budget/models/projects.py
@@ -1035,7 +1035,7 @@ class projects(models.Model):
                             raisetext = raisetext.format(project.project_id, step.step_id, str(end_sale_project_month))
                             return False, raisetext, {'step_id':step.step_id,'end_sale_project_month':str(end_sale_project_month)}
 
-            if project.estimated_probability_id.name in ('0', '100(done)'):
+            if estimated_probability_id_name in ('0', '100(done)'):
                if project.project_have_steps == False:
                    return True, "", {}
 


### PR DESCRIPTION
ошибка в check_overdue_date не давала сохранить проект в "0" вероятности с просроченным прогнозом.